### PR TITLE
Add rate limit control for worker

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -28,6 +28,7 @@
 ```json
 {
   "concurrency": 10,
+  "rate_per_thread": 100,
   "db_conn_str": "user:password@tcp(127.0.0.1:4000)/dbname?parseTime=true",
   "use_transaction": true,
   "connection_type": "long",

--- a/README-zh.md
+++ b/README-zh.md
@@ -28,6 +28,7 @@
 ```json
 {
   "concurrency": 10,
+  "rate_per_thread": 100,
   "db_conn_str": "user:password@tcp(127.0.0.1:4000)/dbname?parseTime=true",
   "use_transaction": true,
   "connection_type": "long",

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 // Config is the main configuration structure
 type Config struct {
 	Concurrency    int        `json:"concurrency"`
+	RatePerThread  int        `json:"rate_per_thread"`
 	DBConnStr      string     `json:"db_conn_str"`
 	ConnectionType string     `json:"connection_type,omitempty"`
 	UseTransaction bool       `json:"use_transaction"`
@@ -22,8 +23,8 @@ type Template struct {
 
 // Param represents a parameter for a SQL query
 type Param struct {
-	Type        string      `json:"type"`
-	RandomMode  string      `json:"random_mode"`
+	Type       string `json:"type"`
+	RandomMode string `json:"random_mode"`
 
 	// Number
 	Min       *int64   `json:"min,omitempty"`

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database_workload/config"
 	"database_workload/generator"
+	"fmt"
 
 	// "fmt"
 	"log"
@@ -80,11 +81,14 @@ func New(id int, cfg *config.Config) (*Worker, error) {
 // Run starts the worker's loop. It stops when the context is cancelled.
 func (w *Worker) Run(ctx context.Context) {
 	var rateLimiter *time.Ticker
+	rateExplain := "no limit"
 	if w.rate > 0 {
 		rateLimiter = time.NewTicker(time.Second / time.Duration(w.rate))
+		defer rateLimiter.Stop()
+		rateExplain = fmt.Sprintf("%d TPS", w.rate)
 	}
-	log.Printf("Worker %d started, rate: %d", w.id, w.rate)
-	defer rateLimiter.Stop()
+
+	log.Printf("Worker %d started, rate: %s", w.id, rateExplain)
 	for {
 		select {
 		case <-ctx.Done():

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -5,9 +5,8 @@ import (
 	"database/sql"
 	"database_workload/config"
 	"database_workload/generator"
-	"fmt"
 
-	// "fmt"
+	"fmt"
 	"log"
 	"strings"
 	"time"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -92,7 +92,7 @@ func (w *Worker) Run(ctx context.Context) {
 			return
 		default:
 			w.runSession(ctx)
-			if rateLimiter == nil {
+			if rateLimiter != nil {
 				<-rateLimiter.C
 			}
 		}


### PR DESCRIPTION
Add a configuration field `rate_per_thread`, which limit the transaction per second for each worker thread. Through this rate limit mechanism, we can get stable workload.

The default value `0` means no limitation.